### PR TITLE
chore: change example port

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm run all
 
 ## Example
 
-To run the example, execute `npm run start` and open http://localhost:5000/public in your Webbrowser.
+To run the example, execute `npm run start` and open http://localhost:9869/public in your Webbrowser.
 
 ## Resources
 

--- a/example/README.md
+++ b/example/README.md
@@ -14,7 +14,7 @@ npm install
 npm start
 ```
 
-This puts up the example to [localhost:5000/public/index.html](http://localhost:5000/public/index.html).
+This puts up the example to [localhost:9869/public/index.html](http://localhost:9869/public/index.html).
 
 
 ## License

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "description": "An example using react-bpmn inside a React application",
   "private": true,
   "scripts": {
-    "start": "sirv . start --dev --port=5000"
+    "start": "sirv . start --dev --port=9869"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
### Proposed Changes

Port 5000 does not work on MacOS anymore.
Related to https://stackoverflow.com/questions/70913242/access-to-localhost-was-denied-you-dont-have-authorization-to-view-this-page-h

Apparently 9869 is free: https://www.speedguide.net/port.php?port=9869

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
